### PR TITLE
Add reset button functionality to all prompt pages

### DIFF
--- a/src/app/components/ChatInterface.tsx
+++ b/src/app/components/ChatInterface.tsx
@@ -16,6 +16,7 @@ interface ChatInterfaceProps {
   showInput?: boolean;
   placeholder?: string;
   removeExpertPrefix?: boolean;
+  onReset?: () => void;
 }
 
 export default function ChatInterface({
@@ -26,7 +27,8 @@ export default function ChatInterface({
   loading,
   showInput = true,
   placeholder = "Type your response...",
-  removeExpertPrefix = false
+  removeExpertPrefix = false,
+  onReset
 }: ChatInterfaceProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -75,6 +77,19 @@ export default function ChatInterface({
             )}
           </div>
         ))}
+
+        {onReset && (
+          <div className="flex justify-end pt-2">
+            <button
+              type="button"
+              onClick={onReset}
+              className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700 shadow-md text-sm"
+              disabled={loading}
+            >
+              Reset Conversation
+            </button>
+          </div>
+        )}
 
         {showInput && (
           <form onSubmit={onSubmit} className="flex space-x-2 pt-2">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -25,6 +25,26 @@ export default function Dashboard() {
     },
   ]);
 
+  const handleReset = () => {
+    setStep(0);
+    setInput('');
+    setLoading(false);
+    setResult('');
+    setContext({
+      drug: '',
+      disease: '',
+      audience: '',
+      intensity: '',
+      count: '',
+    });
+    setMessages([
+      {
+        role: 'assistant',
+        content: 'What drug or intervention are you exploring today?',
+      },
+    ]);
+  };
+
   const questions = [
     'What drug or intervention are you exploring today?',
     'What disease or condition is being treated?',
@@ -115,6 +135,7 @@ export default function Dashboard() {
             loading={loading}
             showInput={step <= questions.length - 1}
             placeholder="Type your response..."
+            onReset={handleReset}
           />
         </div>
 

--- a/src/app/scientific-investigation/landmark-publications/page.tsx
+++ b/src/app/scientific-investigation/landmark-publications/page.tsx
@@ -31,6 +31,23 @@ export default function LandmarkPublicationsPage() {
   const [result, setResult] = useState('');
   const [showFinalMessage, setShowFinalMessage] = useState(false);
 
+  const handleReset = () => {
+    setStep(0);
+    setAnswers([]);
+    setInput('');
+    setMessages([
+      {
+        role: 'assistant',
+        content:
+          'OK, before we get started, please provide the information below. (Please answer each question one at a time):\n\n1. ' +
+          questions[0],
+      },
+    ]);
+    setLoading(false);
+    setResult('');
+    setShowFinalMessage(false);
+  };
+
   const formatLandmarkResult = (content: string) => {
     // Format the numbered response according to requirements
     // Each number on new line, remove vertical bars and quotes
@@ -118,6 +135,7 @@ export default function LandmarkPublicationsPage() {
             loading={loading}
             showInput={!showFinalMessage}
             placeholder="Type your response..."
+            onReset={handleReset}
           />
         </div>
 

--- a/src/app/scientific-investigation/top-publications/page.tsx
+++ b/src/app/scientific-investigation/top-publications/page.tsx
@@ -17,6 +17,20 @@ export default function TopPublicationsPage() {
   const [interviewStarted, setInterviewStarted] = useState(false);
   const [expertInfo, setExpertInfo] = useState('');
 
+  const handleReset = () => {
+    setInput('');
+    setMessages([
+      {
+        role: 'assistant',
+        content:
+          'Great. I will simulate an interview with an expert. Please provide the following information:\n\nWhich would you like to interview (pick one):\n• A specific individual - please provide the full name of the person\n• An expert in a particular field - please provide the field or specialization and if a specific experience or background is desired',
+      },
+    ]);
+    setLoading(false);
+    setInterviewStarted(false);
+    setExpertInfo('');
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim()) return;
@@ -104,6 +118,7 @@ export default function TopPublicationsPage() {
                 : "Specify the expert you'd like to interview..."
             }
             removeExpertPrefix={true}
+            onReset={handleReset}
           />
         </div>
       </div>

--- a/src/app/slide-presentation/deck-generation/page.tsx
+++ b/src/app/slide-presentation/deck-generation/page.tsx
@@ -33,6 +33,23 @@ export default function DeckGenerationPage() {
   const [result, setResult] = useState('');
   const [showFinalMessage, setShowFinalMessage] = useState(false);
 
+  const handleReset = () => {
+    setStep(0);
+    setAnswers([]);
+    setInput('');
+    setMessages([
+      {
+        role: 'assistant',
+        content:
+          'Got it - you need me to generate an outline for a MEDSTORY® presentation deck. First I will need a few bits of information to generate your optimized presentation deck. This should not take long - just 8 quick questions and we will be on our way.\n\n1. ' +
+          questions[0],
+      },
+    ]);
+    setLoading(false);
+    setResult('');
+    setShowFinalMessage(false);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!input.trim()) return;
@@ -142,6 +159,7 @@ Generate the entire outline without stopping for user input.
             loading={loading}
             showInput={!showFinalMessage}
             placeholder="Type your response..."
+            onReset={handleReset}
           />
         </div>
 


### PR DESCRIPTION
## Summary
This PR adds a reset button functionality to all prompt pages in the MedStory AI application, allowing users to clear their current interaction/response with the AI and start over from the beginning.

## Changes Made
- **Modified ChatInterface component** to accept an optional `onReset` prop and display a red reset button when provided
- **Added reset functionality to 4 prompt pages:**
  - `landmark-publications` (Scientific Investigation)
  - `deck-generation` (Slide Presentation) 
  - `top-publications` (Expert Interview)
  - `dashboard` (Core Story Concept Creation)

## Technical Details
- Each reset function clears:
  - Chat messages
  - Input field content
  - Loading states
  - Page-specific state (steps, answers, results, etc.)
- Reset button is:
  - Styled with red background for clear visual distinction
  - Disabled during loading states to prevent conflicts
  - Only displayed when `onReset` prop is provided
- All existing functionality remains unchanged

## Testing
- ✅ Tested reset functionality on all 4 prompt pages
- ✅ Verified button appears and functions correctly
- ✅ Confirmed all state is properly cleared on reset
- ✅ Verified existing chat functionality remains intact
- ✅ Tested button disabled state during loading

## User Experience
Users can now easily start fresh conversations on any prompt page without needing to refresh the browser or navigate away and back to the page. The reset button provides a clear, intuitive way to clear the current interaction and begin again.

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7e7a8901c8564a3aa8688a853a911855)