### PR TITLE
Add back button to Science Branding and fix sidebar icon alignment

### DIFF
--- a/src/app/SidebarMenu.tsx
+++ b/src/app/SidebarMenu.tsx
@@ -106,8 +106,8 @@ function SidebarMenu() {
   }) {
     return (
       <div>
-        <div className="flex flex-col items-start mb-2">
-          <div className="text-2xl mb-1">{title}</div>
+        <div className="flex items-center mb-2">
+          <div className="text-2xl mr-3">{title}</div>
           <p className="font-bold text-white text-sm">{sectionName}</p>
         </div>
         <ul className="ml-4 space-y-1 text-gray-200">

--- a/src/app/components/PageLayout.tsx
+++ b/src/app/components/PageLayout.tsx
@@ -40,12 +40,37 @@ export default function PageLayout({
       {/* Main Content */}
       <main className="flex-1 bg-gray-50 p-12">
         {/* Header with Section and Task */}
-        <div className="flex items-center mb-10">
-          <span className="text-4xl mr-4">{sectionIcon}</span>
-          <div>
-            <h1 className="text-3xl font-extrabold text-[#063471]">{sectionName}</h1>
-            <h2 className="text-xl text-gray-600 mt-1">{taskName}</h2>
+        <div className="flex items-center justify-between mb-10">
+          <div className="flex items-center">
+            <span className="text-4xl mr-4">{sectionIcon}</span>
+            <div>
+              <h1 className="text-3xl font-extrabold text-[#063471]">{sectionName}</h1>
+              <h2 className="text-xl text-gray-600 mt-1">{taskName}</h2>
+            </div>
           </div>
+          
+          {/* Back Button */}
+          <a
+            href="https://sciencebranding.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center px-4 py-2 bg-[#002F6C] text-white rounded-lg hover:bg-[#063471] transition-colors duration-200 font-medium"
+          >
+            <svg 
+              className="w-4 h-4 mr-2" 
+              fill="none" 
+              stroke="currentColor" 
+              viewBox="0 0 24 24"
+            >
+              <path 
+                strokeLinecap="round" 
+                strokeLinejoin="round" 
+                strokeWidth={2} 
+                d="M10 19l-7-7m0 0l7-7m-7 7h18" 
+              />
+            </svg>
+            Back to Science Branding
+          </a>
         </div>
 
         {children}


### PR DESCRIPTION
## Summary
This PR implements two UI improvements requested by the user:

1. **Added Back Button**: A "Back to Science Branding" button that redirects to sciencebranding.com
2. **Fixed Sidebar Icon Alignment**: Corrected sidebar menu icons to display on the same line as their headers instead of above them

## Changes Made

### 🔙 Back Button Implementation
- Added a styled "Back to Science Branding" button in the `PageLayout` component header
- Positioned in the top-right corner of the main content area
- Features:
  - Clean design matching the app's color scheme (dark blue background)
  - Left arrow icon for clear visual indication
  - Hover effects for better UX
  - Opens in new tab with proper security attributes (`target="_blank"`, `rel="noopener noreferrer"`)
  - Redirects to https://sciencebranding.com

### 🎨 Sidebar Icon Alignment Fix
- Modified the `Section` component in `SidebarMenu.tsx`
- Changed layout from vertical stacking to horizontal alignment
- Icons (🔬, 🎤, 🎯, 🗺️, 📽️) now appear to the left of section headers on the same line
- Improved visual hierarchy and professional appearance

## Files Modified
- `src/app/components/PageLayout.tsx` - Added back button to header
- `src/app/SidebarMenu.tsx` - Fixed icon alignment in section headers

## Impact
- Changes apply automatically to all pages using the `PageLayout` component:
  - Scientific Investigation pages
  - Dashboard/Story Flow Map pages  
  - Slide Presentation pages
  - Any future pages using PageLayout

## Testing
- ✅ Back button successfully redirects to sciencebranding.com
- ✅ Sidebar icons properly aligned on all pages
- ✅ Responsive design maintained
- ✅ No breaking changes to existing functionality

## Screenshots
The changes have been tested and verified to work correctly across multiple pages in the application.

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/26f1e319cb624f1f99d684b755b94dca)