### PR TITLE
Increase sectionIcon sizes for better visibility

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -120,7 +120,9 @@ export default function Dashboard() {
 
   return (
     <PageLayout
-      sectionIcon={<img src="/story_flow_map_chat.png" alt="Core Story Chat" className="w-8 h-8" />}
+      sectionIcon={
+        <img src="/story_flow_map_chat.png" alt="Core Story Chat" className="w-12 h-12" />
+      }
       sectionName="Story Flow Map"
       taskName="Create tension-resolution points"
     >

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -120,7 +120,7 @@ export default function Dashboard() {
 
   return (
     <PageLayout
-      sectionIcon={<img src="/story_flow_map_chat.png" alt="Core Story Chat" className="w-6 h-6" />}
+      sectionIcon={<img src="/story_flow_map_chat.png" alt="Core Story Chat" className="w-8 h-8" />}
       sectionName="Story Flow Map"
       taskName="Create tension-resolution points"
     >

--- a/src/app/scientific-investigation/landmark-publications/page.tsx
+++ b/src/app/scientific-investigation/landmark-publications/page.tsx
@@ -143,7 +143,7 @@ export default function LandmarkPublicationsPage() {
   return (
     <PageLayout
       sectionIcon={
-        <img src="/scientific_investigation_chat.png" alt="Core Story Chat" className="w-8 h-8" />
+        <img src="/scientific_investigation_chat.png" alt="Core Story Chat" className="w-12 h-12" />
       }
       sectionName="Scientific Investigation"
       taskName="Find landmark publications"

--- a/src/app/scientific-investigation/landmark-publications/page.tsx
+++ b/src/app/scientific-investigation/landmark-publications/page.tsx
@@ -143,7 +143,7 @@ export default function LandmarkPublicationsPage() {
   return (
     <PageLayout
       sectionIcon={
-        <img src="/scientific_investigation_chat.png" alt="Core Story Chat" className="w-6 h-6" />
+        <img src="/scientific_investigation_chat.png" alt="Core Story Chat" className="w-8 h-8" />
       }
       sectionName="Scientific Investigation"
       taskName="Find landmark publications"

--- a/src/app/scientific-investigation/top-publications/page.tsx
+++ b/src/app/scientific-investigation/top-publications/page.tsx
@@ -100,7 +100,7 @@ export default function TopPublicationsPage() {
   return (
     <PageLayout
       sectionIcon={
-        <img src="/stakeholder_interviews_chat.png" alt="Core Story Chat" className="w-8 h-8" />
+        <img src="/stakeholder_interviews_chat.png" alt="Core Story Chat" className="w-12 h-12" />
       }
       sectionName="Stakeholder Interviews"
       taskName="Simulated thought leader interview"

--- a/src/app/scientific-investigation/top-publications/page.tsx
+++ b/src/app/scientific-investigation/top-publications/page.tsx
@@ -100,7 +100,7 @@ export default function TopPublicationsPage() {
   return (
     <PageLayout
       sectionIcon={
-        <img src="/stakeholder_interviews_chat.png" alt="Core Story Chat" className="w-6 h-6" />
+        <img src="/stakeholder_interviews_chat.png" alt="Core Story Chat" className="w-8 h-8" />
       }
       sectionName="Stakeholder Interviews"
       taskName="Simulated thought leader interview"

--- a/src/app/slide-presentation/deck-generation/page.tsx
+++ b/src/app/slide-presentation/deck-generation/page.tsx
@@ -156,7 +156,7 @@ Generate the entire outline without stopping for user input.
   return (
     <PageLayout
       sectionIcon={
-        <img src="/medstory_slide_deck_chat.png" alt="Core Story Chat" className="w-8 h-8" />
+        <img src="/medstory_slide_deck_chat.png" alt="Core Story Chat" className="w-12 h-12" />
       }
       sectionName="MEDSTORY Slide Deck"
       taskName="Create MEDSTORY deck"

--- a/src/app/slide-presentation/deck-generation/page.tsx
+++ b/src/app/slide-presentation/deck-generation/page.tsx
@@ -156,7 +156,7 @@ Generate the entire outline without stopping for user input.
   return (
     <PageLayout
       sectionIcon={
-        <img src="/medstory_slide_deck_chat.png" alt="Core Story Chat" className="w-6 h-6" />
+        <img src="/medstory_slide_deck_chat.png" alt="Core Story Chat" className="w-8 h-8" />
       }
       sectionName="MEDSTORY Slide Deck"
       taskName="Create MEDSTORY deck"


### PR DESCRIPTION
## Summary
This PR increases the size of sectionIcon images in four key components to improve visibility and user experience.

## Changes Made
- **Find landmark publications**: Updated icon size from `w-6 h-6` to `w-8 h-8`
- **Simulate expert interview**: Updated icon size from `w-6 h-6` to `w-8 h-8`
- **Create tension-resolution points**: Updated icon size from `w-6 h-6` to `w-8 h-8`
- **Create MEDSTORY deck**: Updated icon size from `w-6 h-6` to `w-8 h-8`

## Files Modified
- `src/app/scientific-investigation/landmark-publications/page.tsx`
- `src/app/scientific-investigation/top-publications/page.tsx`
- `src/app/dashboard/page.tsx`
- `src/app/slide-presentation/deck-generation/page.tsx`

## Impact
The section icons are now 33% larger (from 24px × 24px to 32px × 32px), making them more prominent and easier to see in the page headers while maintaining good visual balance.

## Testing
- [x] Verified all four components have updated icon sizes
- [x] Confirmed no other sectionIcon instances need updating
- [x] Changes are consistent across all affected pages

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a477add394e49a9a947e930a906ef01)