### PR TITLE
Add manual save buttons and expert interview saved page

### DIFF
--- a/src/app/scientific-investigation/landmark-publications/page.tsx
+++ b/src/app/scientific-investigation/landmark-publications/page.tsx
@@ -95,13 +95,19 @@ export default function LandmarkPublicationsPage() {
       newSelected.delete(studyId);
     }
     setSelectedStudies(newSelected);
-    
+  };
+
+  // Handle saving selected studies to session storage
+  const handleSaveSelected = () => {
     // Save to session storage
-    sessionStorage.setItem('selectedLandmarkStudies', JSON.stringify(Array.from(newSelected)));
+    sessionStorage.setItem('selectedLandmarkStudies', JSON.stringify(Array.from(selectedStudies)));
     
     // Also save the actual study data
-    const selectedStudyData = studies.filter(study => newSelected.has(study.id));
+    const selectedStudyData = studies.filter(study => selectedStudies.has(study.id));
     sessionStorage.setItem('selectedLandmarkStudiesData', JSON.stringify(selectedStudyData));
+    
+    // Show success message
+    toast.success(`${selectedStudies.size} studies saved successfully!`);
   };
 
   // Handle clicking on title to access hidden page
@@ -251,9 +257,19 @@ export default function LandmarkPublicationsPage() {
             <div className="bg-white border border-gray-300 p-6 rounded-lg shadow-md">
               <div className="flex justify-between items-center mb-4">
                 <h2 className="text-xl font-bold text-blue-900">Landmark Publications</h2>
-                <span className="text-sm text-gray-600">
-                  {selectedStudies.size} selected
-                </span>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-gray-600">
+                    {selectedStudies.size} selected
+                  </span>
+                  {selectedStudies.size > 0 && (
+                    <button
+                      onClick={handleSaveSelected}
+                      className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+                    >
+                      Save Selected
+                    </button>
+                  )}
+                </div>
               </div>
               <div className="space-y-6">
                 {studies.map((study) => (
@@ -288,7 +304,7 @@ export default function LandmarkPublicationsPage() {
               {selectedStudies.size > 0 && (
                 <div className="mt-4 p-3 bg-blue-50 rounded-lg">
                   <p className="text-sm text-blue-800">
-                    💡 Tip: Click on &quot;Find landmark publications&quot; in the header to view your saved studies
+                    💡 Tip: Click &quot;Save Selected&quot; to save your chosen studies, then click &quot;Find landmark publications&quot; in the header to view them
                   </p>
                 </div>
               )}

--- a/src/app/scientific-investigation/top-publications/page.tsx
+++ b/src/app/scientific-investigation/top-publications/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
+import toast from 'react-hot-toast';
 import PageLayout from '@/app/components/PageLayout';
 import ChatInterface from '@/app/components/ChatInterface';
 
@@ -32,6 +33,11 @@ export default function TopPublicationsPage() {
       keyPointsRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [interviewEnded, keyPoints]);
+
+  // Handle clicking on title to access saved page
+  const handleTitleClick = () => {
+    window.location.href = '/scientific-investigation/top-publications/saved';
+  };
 
   const handleReset = () => {
     setInput('');
@@ -108,13 +114,19 @@ export default function TopPublicationsPage() {
       newSelected.delete(pointId);
     }
     setSelectedKeyPoints(newSelected);
+  };
 
+  // Handle saving selected key points to session storage
+  const handleSaveSelected = () => {
     // Save to session storage
-    sessionStorage.setItem('selectedInterviewKeyPoints', JSON.stringify(Array.from(newSelected)));
+    sessionStorage.setItem('selectedInterviewKeyPoints', JSON.stringify(Array.from(selectedKeyPoints)));
 
     // Also save the actual key point data
-    const selectedPointsData = keyPoints.filter((point) => newSelected.has(point.id));
+    const selectedPointsData = keyPoints.filter((point) => selectedKeyPoints.has(point.id));
     sessionStorage.setItem('selectedInterviewKeyPointsData', JSON.stringify(selectedPointsData));
+    
+    // Show success message
+    toast.success(`${selectedKeyPoints.size} key points saved successfully!`);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -195,7 +207,15 @@ export default function TopPublicationsPage() {
         />
       }
       sectionName="Stakeholder Interviews"
-      taskName="Simulated thought leader interview"
+      taskName={
+        <span 
+          onClick={handleTitleClick} 
+          className="cursor-pointer hover:text-blue-600 transition-colors"
+          title="Click to view saved key points"
+        >
+          Simulated thought leader interview
+        </span>
+      }
     >
       <div className="flex flex-col lg:flex-row gap-4">
         {/* Chat Interface - Left Side */}
@@ -224,7 +244,17 @@ export default function TopPublicationsPage() {
             <div className="bg-white border border-gray-300 p-6 rounded-lg shadow-md">
               <div className="flex justify-between items-center mb-4">
                 <h2 className="text-xl font-bold text-blue-900">Key Points from Interview</h2>
-                <span className="text-sm text-gray-600">{selectedKeyPoints.size} selected</span>
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-gray-600">{selectedKeyPoints.size} selected</span>
+                  {selectedKeyPoints.size > 0 && (
+                    <button
+                      onClick={handleSaveSelected}
+                      className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium"
+                    >
+                      Save Selected
+                    </button>
+                  )}
+                </div>
               </div>
               <div className="space-y-6">
                 {keyPoints.map((point) => (
@@ -251,7 +281,7 @@ export default function TopPublicationsPage() {
               {selectedKeyPoints.size > 0 && (
                 <div className="mt-4 p-3 bg-blue-50 rounded-lg">
                   <p className="text-sm text-blue-800">
-                    💡 Tip: Selected key points are saved for your reference
+                    💡 Tip: Click &quot;Save Selected&quot; to save your chosen key points, then click &quot;Simulated thought leader interview&quot; in the header to view them
                   </p>
                 </div>
               )}

--- a/src/app/scientific-investigation/top-publications/saved/page.tsx
+++ b/src/app/scientific-investigation/top-publications/saved/page.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import PageLayout from '@/app/components/PageLayout';
+
+interface KeyPoint {
+  id: string;
+  content: string;
+}
+
+export default function SavedExpertInterviewPage() {
+  const [savedKeyPoints, setSavedKeyPoints] = useState<KeyPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Load saved key points from session storage
+    const loadSavedKeyPoints = () => {
+      try {
+        const savedData = sessionStorage.getItem('selectedInterviewKeyPointsData');
+        if (savedData) {
+          const keyPoints = JSON.parse(savedData);
+          setSavedKeyPoints(keyPoints);
+        }
+      } catch (error) {
+        console.error('Error loading saved key points:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadSavedKeyPoints();
+  }, []);
+
+  const handleRemoveKeyPoint = (keyPointId: string) => {
+    const updatedKeyPoints = savedKeyPoints.filter(point => point.id !== keyPointId);
+    setSavedKeyPoints(updatedKeyPoints);
+    
+    // Update session storage
+    sessionStorage.setItem('selectedInterviewKeyPointsData', JSON.stringify(updatedKeyPoints));
+    
+    // Update the selected IDs list
+    const selectedIds = updatedKeyPoints.map(point => point.id);
+    sessionStorage.setItem('selectedInterviewKeyPoints', JSON.stringify(selectedIds));
+  };
+
+  const handleClearAll = () => {
+    setSavedKeyPoints([]);
+    sessionStorage.removeItem('selectedInterviewKeyPointsData');
+    sessionStorage.removeItem('selectedInterviewKeyPoints');
+  };
+
+  const handleExportKeyPoints = () => {
+    if (savedKeyPoints.length === 0) return;
+    
+    const exportText = savedKeyPoints.map((point, index) => 
+      `${index + 1}. ${point.content}`
+    ).join('\n\n');
+    
+    const blob = new Blob([exportText], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `expert-interview-key-points-${new Date().toISOString().split('T')[0]}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  if (loading) {
+    return (
+      <PageLayout
+        sectionIcon={
+          <Image src="/stakeholder_interviews_chat.png" alt="Core Story Chat" width={72} height={72} className="w-18 h-18" />
+        }
+        sectionName="Stakeholder Interviews"
+        taskName="Saved Interview Key Points"
+      >
+        <div className="flex items-center justify-center h-64">
+          <div className="text-center">
+            <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-blue-600 border-r-transparent"></div>
+            <p className="mt-4 text-lg text-gray-600">Loading saved key points...</p>
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      sectionIcon={
+        <Image src="/stakeholder_interviews_chat.png" alt="Core Story Chat" width={72} height={72} className="w-18 h-18" />
+      }
+      sectionName="Stakeholder Interviews"
+      taskName="Saved Interview Key Points"
+    >
+      <div className="max-w-4xl mx-auto">
+        <div className="bg-white border border-gray-300 p-6 rounded-lg shadow-md">
+          <div className="flex justify-between items-center mb-6">
+            <div>
+              <h1 className="text-2xl font-bold text-blue-900">Saved Interview Key Points</h1>
+              <p className="text-gray-600 mt-1">
+                {savedKeyPoints.length} {savedKeyPoints.length === 1 ? 'key point' : 'key points'} saved
+              </p>
+            </div>
+            {savedKeyPoints.length > 0 && (
+              <div className="flex gap-2">
+                <button
+                  onClick={handleExportKeyPoints}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm"
+                >
+                  Export
+                </button>
+                <button
+                  onClick={handleClearAll}
+                  className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm"
+                >
+                  Clear All
+                </button>
+              </div>
+            )}
+          </div>
+
+          {savedKeyPoints.length === 0 ? (
+            <div className="text-center py-12">
+              <div className="text-gray-400 mb-4">
+                <svg className="mx-auto h-12 w-12" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+              </div>
+              <h3 className="text-lg font-medium text-gray-900 mb-2">No saved key points</h3>
+              <p className="text-gray-600 mb-4">
+                You haven&apos;t saved any interview key points yet. Go back to the expert interview page and select key points to save them here.
+              </p>
+              <a
+                href="/scientific-investigation/top-publications"
+                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                Start Expert Interview
+              </a>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {savedKeyPoints.map((point, index) => (
+                <div key={point.id} className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex-1">
+                      <div className="font-medium text-gray-900 mb-2">
+                        Key Point {index + 1}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleRemoveKeyPoint(point.id)}
+                      className="ml-4 text-red-600 hover:text-red-800 transition-colors"
+                      title="Remove key point"
+                    >
+                      <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      </svg>
+                    </button>
+                  </div>
+                  <div className="text-gray-700 text-sm leading-relaxed">
+                    {point.content}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {savedKeyPoints.length > 0 && (
+            <div className="mt-6 p-4 bg-blue-50 rounded-lg">
+              <h3 className="font-medium text-blue-900 mb-2">Using Your Saved Key Points</h3>
+              <p className="text-sm text-blue-800">
+                These saved key points are stored in your browser session and can be used for other prompts and analysis. 
+                You can export them as a text file or continue adding more key points from expert interviews.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </PageLayout>
+  );
+}


### PR DESCRIPTION
## Summary

This PR implements the requested changes to improve the user experience for saving items in both landmark publications and expert interviews:

### Changes Made

#### 🔄 **Manual Save Functionality**
- **Landmark Publications**: Replaced automatic saving with a manual "Save Selected" button that appears when items are checked
- **Expert Interview**: Replaced automatic saving with a manual "Save Selected" button for key points

#### 📄 **Expert Interview Saved Page**
- Created a new saved page (`/scientific-investigation/top-publications/saved`) for expert interview key points
- Mirrors the functionality of the landmark publications saved page
- Includes export, clear all, and individual item removal features

#### 🔗 **Enhanced Navigation**
- Made task titles clickable to navigate to respective saved pages
- "Find landmark publications" → navigates to landmark publications saved page
- "Simulated thought leader interview" → navigates to expert interview saved page

#### 💡 **Updated User Guidance**
- Updated tip messages to reflect the new manual saving workflow
- Clear instructions on how to save and access saved items

### User Experience Improvements

1. **User Control**: Users now have explicit control over when items are saved to session storage
2. **Consistent Behavior**: Both landmark publications and expert interviews now have the same save/view pattern
3. **Clear Feedback**: Toast notifications confirm successful saves
4. **Easy Access**: Clickable titles provide intuitive navigation to saved items

### Technical Details

- Maintains backward compatibility with existing session storage structure
- Uses the same session storage keys and data format
- No breaking changes to existing functionality
- All existing features (export, clear all, individual removal) preserved

### Testing

- ✅ Manual save buttons appear only when items are selected
- ✅ Toast notifications work correctly
- ✅ Navigation between pages functions properly
- ✅ Session storage persistence works as expected
- ✅ Export and management features work on both saved pages

This implementation addresses the user's request for manual saving control while maintaining the existing saved page functionality for landmark publications and extending it to expert interviews.

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e8ff5a49cde34c4f94fa8514dc8d7d89)