### PR TITLE
Fix landmark publications page number format issue

### DIFF
--- a/src/app/scientific-investigation/landmark-publications/page.tsx
+++ b/src/app/scientific-investigation/landmark-publications/page.tsx
@@ -67,9 +67,10 @@ export default function LandmarkPublicationsPage() {
     return studyBlocks.map((block, index) => {
       const lines = block.trim().split('\n');
       const citationLine = lines[0] || '';
-      const impactLine = lines.find((line) => line.includes('Impact Score')) || '';
+      // Specifically look for the line that starts with "Impact Score"
+      const impactLine = lines.find((line) => line.trim().startsWith('Impact Score')) || '';
       const descriptionLines = lines.filter(
-        (line) => !line.match(/^\d+\./) && !line.includes('Impact Score')
+        (line) => !line.match(/^\d+\./) && !line.trim().startsWith('Impact Score')
       );
 
       const numberMatch = citationLine.match(/^(\d+)\./);


### PR DESCRIPTION
## Description
This PR fixes an issue with the landmark publications result format where page numbers with hyphens were being incorrectly split, causing the impact score to appear on a separate line.

## Problem
When a citation included a page range with a hyphen (e.g., "453-461"), the page number was getting cut off at the hyphen, and then the impact score line was appearing incorrectly.

## Solution
Modified the `parseStudies` function in `src/app/scientific-investigation/landmark-publications/page.tsx` to more precisely identify the impact score line by checking if it starts with "Impact Score" rather than just includes it. This ensures that the page number with a hyphen is not incorrectly split, and the impact score is correctly identified as a separate line.

## Changes
- Updated the `parseStudies` function to use `line.trim().startsWith('Impact Score')` instead of `line.includes('Impact Score')`
- Updated the filter for description lines to also use `line.trim().startsWith('Impact Score')` for consistency

## Testing
The changes have been tested locally and the page numbers with hyphens now display correctly, followed by the impact score on a new line.

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/587d26bc86f84f6b8da20e9c3bd95734)