### PR TITLE
Update app background color to #ededed

### DIFF
--- a/src/app/components/PageLayout.tsx
+++ b/src/app/components/PageLayout.tsx
@@ -60,9 +60,9 @@ export default function PageLayout({
         </div>
       </aside>
       {/* Main Content */}
-      <main className="flex-1 bg-gray-50 flex flex-col overflow-hidden ml-72">
+      <main className="flex-1 bg-[#ededed] flex flex-col overflow-hidden ml-72">
         {/* Fixed Header with Section and Task */}
-        <div className="flex items-center justify-between p-12 pb-6 flex-shrink-0 bg-gray-50">
+        <div className="flex items-center justify-between p-12 pb-6 flex-shrink-0 bg-[#ededed]">
           <div className="flex items-center">
             <span className="text-4xl mr-4">{sectionIcon}</span>
             <div>

--- a/src/app/enter/page.tsx
+++ b/src/app/enter/page.tsx
@@ -34,7 +34,7 @@ export default function EnterPage() {
       </aside>
 
       {/* Main Content */}
-      <main className="flex-1 bg-gray-50 p-12 ml-80">
+      <main className="flex-1 bg-[#ededed] p-12 ml-80">
         <div className="max-w-4xl">
           {/* Header with logo */}
           <div className="flex justify-between items-start mb-8">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 :root {
-  --background: #ffffff;
+  --background: #ededed;
   --foreground: #171717;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ export const metadata = {
 
 function LoadingFallback() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+    <div className="flex min-h-screen items-center justify-center bg-[#ededed]">
       <div className="text-center">
         <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-blue-600 border-r-transparent"></div>
         <p className="mt-4 text-lg text-gray-600">Loading MedStory AI...</p>

--- a/src/app/scientific-investigation/landmark-publications/loading.tsx
+++ b/src/app/scientific-investigation/landmark-publications/loading.tsx
@@ -15,7 +15,7 @@ export default function Loading() {
       </aside>
 
       {/* Main Content Skeleton */}
-      <main className="flex-1 bg-gray-50 p-12">
+      <main className="flex-1 bg-[#ededed] p-12">
         <div className="flex items-center mb-10">
           <span className="text-4xl mr-4">🔬</span>
           <div>


### PR DESCRIPTION
## Changes

This PR updates the background color of the app to `#ededed` as requested, while keeping the sidebar menu unchanged.

### Modified Files:
- `src/app/globals.css`: Updated the root CSS variable `--background` to `#ededed`
- `src/app/components/PageLayout.tsx`: Changed background color from `bg-gray-50` to `bg-[#ededed]`
- `src/app/enter/page.tsx`: Changed background color from `bg-gray-50` to `bg-[#ededed]`
- `src/app/layout.tsx`: Updated LoadingFallback component background from `bg-gray-50` to `bg-[#ededed]`
- `src/app/scientific-investigation/landmark-publications/loading.tsx`: Changed background color from `bg-gray-50` to `bg-[#ededed]`

### Visual Changes:
- All pages now have a consistent background color of `#ededed`
- The sidebar menu remains unchanged as requested

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f0396b4e360d49b782e1a267d3089364)