### PR TITLE
Fix attack point modification in tension-resolution page

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -543,12 +543,21 @@ export default function TensionResolution() {
         // Parse the content to extract different sections
         const parsedContent = parseContentResponse(data.result);
 
-        // Determine if this is a modification or new creation based on user input
+        // Determine if this is a modification or new creation based on user input and AI response
         const isModifyingAttackPoint = trimmed.toLowerCase().includes('modif');
+        
+        // Check if the previous AI message was asking for modifications
+        const previousAIMessage = messages.length >= 2 ? messages[messages.length - 2] : null;
+        const isRespondingToModificationRequest = 
+          previousAIMessage && 
+          previousAIMessage.role === 'assistant' && 
+          (previousAIMessage.content.toLowerCase().includes('what modifications would you like to make') ||
+           previousAIMessage.content.toLowerCase().includes('modifications would you like to make to the current attack point'));
+        
         // const isCreatingNewAttackPoint = trimmed.toLowerCase().includes('new') || trimmed.toLowerCase().includes('create');
 
         if (parsedContent.attackPoints.length > 0) {
-          if (isModifyingAttackPoint) {
+          if (isModifyingAttackPoint || isRespondingToModificationRequest) {
             updateAttackPoints(parsedContent.attackPoints, 'modify');
           } else {
             // Default to 'add' so Attack Point #1, #2, etc., accumulate


### PR DESCRIPTION
## Problem
In the tension-resolution page, when a user chooses to "modify" an attack point and the AI responds with "What modifications would you like to make to the current Attack Point?", the user's subsequent input creates a new attack point instead of modifying the existing one.

## Solution
This PR fixes the issue by:

1. Enhancing the logic that determines whether to modify an existing attack point or add a new one.
2. Adding a check to see if the user is responding to a modification request from the AI.
3. Improving the detection of the AI's modification request message by looking for both "what modifications would you like to make" and "modifications would you like to make to the current attack point" in the previous AI message.

## Changes
- Updated the code in `src/app/story-flow-map/tension-resolution/page.tsx` to check both the user's input and the previous AI message to determine if the user is responding to a modification request.
- Added more robust pattern matching for the AI's modification request message.

## Testing
The changes have been tested to ensure that:
- When a user chooses to "modify" an attack point, the AI responds with "What modifications would you like to make to the current Attack Point?"
- When the user provides their modifications, the latest attack point is updated instead of creating a new one.
- The existing functionality for creating new attack points is preserved.