### PR TITLE
Fix: Remove unwanted question string from attack points in tension-resolution

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -133,7 +133,8 @@ export default function TensionResolution() {
 
   // Helper function to clean attack points by removing unwanted strings
   const cleanAttackPoint = (attackPoint: string): string => {
-    const unwantedString = "Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?";
+    const unwantedString =
+      'Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?';
     return attackPoint.replace(unwantedString, '').trim();
   };
 
@@ -143,8 +144,10 @@ export default function TensionResolution() {
     mode: 'replace' | 'add' | 'modify' = 'replace'
   ) => {
     // Clean all new points before processing
-    const cleanedNewPoints = newPoints.map(point => cleanAttackPoint(point)).filter(point => point.length > 0);
-    
+    const cleanedNewPoints = newPoints
+      .map((point) => cleanAttackPoint(point))
+      .filter((point) => point.length > 0);
+
     if (mode === 'add') {
       const updatedPoints = [...persistentAttackPoints, ...cleanedNewPoints];
       setAttackPoints(updatedPoints);
@@ -490,7 +493,8 @@ export default function TensionResolution() {
 
           // Update state with parsed content - only add new attack points if found
           if (parsedContent.attackPoints.length > 0) {
-            updateAttackPoints(parsedContent.attackPoints, 'add');
+            const cleaned = parsedContent.attackPoints.map(cleanAttackPoint);
+            updateAttackPoints(cleaned, 'add');
           }
           if (parsedContent.tensionResolutionPoints.length > 0) {
             setTensionResolutionPoints(parsedContent.tensionResolutionPoints);
@@ -581,11 +585,12 @@ export default function TensionResolution() {
         const previousAIMessage = messages.length >= 2 ? messages[messages.length - 2] : null;
 
         if (parsedContent.attackPoints.length > 0) {
+          const cleaned = parsedContent.attackPoints.map(cleanAttackPoint);
           if (previousAIMessage && previousAIMessage.content.includes('modif')) {
-            updateAttackPoints(parsedContent.attackPoints, 'modify');
+            updateAttackPoints(cleaned, 'modify');
           } else {
             // Default to 'add' so Attack Point #1, #2, etc., accumulate
-            updateAttackPoints(parsedContent.attackPoints, 'add');
+            updateAttackPoints(cleaned, 'add');
           }
         }
 

--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -131,26 +131,35 @@ export default function TensionResolution() {
     }
   }, []);
 
+  // Helper function to clean attack points by removing unwanted strings
+  const cleanAttackPoint = (attackPoint: string): string => {
+    const unwantedString = "Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?";
+    return attackPoint.replace(unwantedString, '').trim();
+  };
+
   // Helper function to safely update attack points with persistent backup
   const updateAttackPoints = (
     newPoints: string[],
     mode: 'replace' | 'add' | 'modify' = 'replace'
   ) => {
+    // Clean all new points before processing
+    const cleanedNewPoints = newPoints.map(point => cleanAttackPoint(point)).filter(point => point.length > 0);
+    
     if (mode === 'add') {
-      const updatedPoints = [...persistentAttackPoints, ...newPoints];
+      const updatedPoints = [...persistentAttackPoints, ...cleanedNewPoints];
       setAttackPoints(updatedPoints);
       setPersistentAttackPoints(updatedPoints);
     } else if (mode === 'modify') {
       const updatedPoints = [...persistentAttackPoints];
-      if (updatedPoints.length > 0 && newPoints.length > 0) {
+      if (updatedPoints.length > 0 && cleanedNewPoints.length > 0) {
         // Replace last attack point with the modified version
-        updatedPoints[updatedPoints.length - 1] = newPoints[0];
+        updatedPoints[updatedPoints.length - 1] = cleanedNewPoints[0];
       }
       setAttackPoints(updatedPoints);
       setPersistentAttackPoints(updatedPoints);
     } else {
-      setAttackPoints(newPoints);
-      setPersistentAttackPoints(newPoints);
+      setAttackPoints(cleanedNewPoints);
+      setPersistentAttackPoints(cleanedNewPoints);
     }
   };
 
@@ -180,7 +189,10 @@ export default function TensionResolution() {
         if (currentSection && currentContent.length > 0) {
           // Save previous section
           if (currentSection === 'attack') {
-            attackPointsFound.push(currentContent.join('\n').trim());
+            const cleanedAttackPoint = cleanAttackPoint(currentContent.join('\n').trim());
+            if (cleanedAttackPoint) {
+              attackPointsFound.push(cleanedAttackPoint);
+            }
           }
         }
         currentSection = 'attack';
@@ -193,7 +205,10 @@ export default function TensionResolution() {
         if (currentSection && currentContent.length > 0) {
           // Save previous section
           if (currentSection === 'attack') {
-            attackPointsFound.push(currentContent.join('\n').trim());
+            const cleanedAttackPoint = cleanAttackPoint(currentContent.join('\n').trim());
+            if (cleanedAttackPoint) {
+              attackPointsFound.push(cleanedAttackPoint);
+            }
           } else if (currentSection === 'tension') {
             tensionResolutionPointsFound.push(currentContent.join('\n').trim());
           }
@@ -208,7 +223,10 @@ export default function TensionResolution() {
         if (currentSection && currentContent.length > 0) {
           // Save previous section
           if (currentSection === 'attack') {
-            attackPointsFound.push(currentContent.join('\n').trim());
+            const cleanedAttackPoint = cleanAttackPoint(currentContent.join('\n').trim());
+            if (cleanedAttackPoint) {
+              attackPointsFound.push(cleanedAttackPoint);
+            }
           } else if (currentSection === 'tension') {
             tensionResolutionPointsFound.push(currentContent.join('\n').trim());
           }
@@ -223,7 +241,10 @@ export default function TensionResolution() {
         if (currentSection && currentContent.length > 0) {
           // Save previous section
           if (currentSection === 'attack') {
-            attackPointsFound.push(currentContent.join('\n').trim());
+            const cleanedAttackPoint = cleanAttackPoint(currentContent.join('\n').trim());
+            if (cleanedAttackPoint) {
+              attackPointsFound.push(cleanedAttackPoint);
+            }
           } else if (currentSection === 'tension') {
             tensionResolutionPointsFound.push(currentContent.join('\n').trim());
           } else if (currentSection === 'conclusion') {
@@ -244,7 +265,10 @@ export default function TensionResolution() {
     // Save the last section
     if (currentSection && currentContent.length > 0) {
       if (currentSection === 'attack') {
-        attackPointsFound.push(currentContent.join('\n').trim());
+        const cleanedAttackPoint = cleanAttackPoint(currentContent.join('\n').trim());
+        if (cleanedAttackPoint) {
+          attackPointsFound.push(cleanedAttackPoint);
+        }
       } else if (currentSection === 'tension') {
         tensionResolutionPointsFound.push(currentContent.join('\n').trim());
       } else if (currentSection === 'conclusion') {


### PR DESCRIPTION
## Problem
The tension-resolution page was displaying an unwanted question string within the attack points in the results section: "Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?"

This string was appearing as part of the attack point content instead of only being shown in the chat interface where it belongs.

## Solution
This PR implements a comprehensive solution to filter out the unwanted string from attack points while preserving the chat functionality:

### Changes Made
- **Added `cleanAttackPoint()` helper function**: Removes the specific unwanted string from attack point content
- **Updated `parseContentResponse()` function**: Applies cleaning to all attack points during the parsing process
- **Enhanced `updateAttackPoints()` function**: Cleans incoming attack points from any source before processing
- **Preserved chat functionality**: The question string remains in chat messages as intended

### Technical Details
- The cleaning function uses string replacement to remove the exact unwanted text
- Empty attack points (after cleaning) are filtered out to prevent blank entries
- Multiple layers of protection ensure the string is removed regardless of where it originates
- All existing functionality is preserved - only the display of attack points is affected

## Testing
- Verified that the unwanted string is removed from attack points in the results section
- Confirmed that chat functionality continues to work as expected
- Ensured no other functionality is affected by the changes

## Files Changed
- `src/app/story-flow-map/tension-resolution/page.tsx`

This fix ensures a cleaner user experience by removing the unwanted question text from the attack points display while maintaining all existing functionality.