### PR TITLE
Fix references not being separated from conclusion in tension-resolution page

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -171,9 +171,25 @@ export default function TensionResolution() {
     return cleaned;
   };
 
-  // Helper function to clean conclusion content
+  // Helper function to clean conclusion content and separate references if found
   const cleanConclusion = (conclusion: string): string => {
     let cleaned = conclusion.trim();
+    
+    // Check if references section is embedded within conclusion
+    // This pattern matches various forms of "References" headings
+    const referencesMatch = cleaned.match(/\n\s*\*?\*?References?\*?\*?[:\s]*/i) || 
+                           cleaned.match(/\n\s*\[References?\]/i) ||
+                           cleaned.match(/\n\s*References? section/i) ||
+                           (cleaned.startsWith("References") && cleaned.match(/^References?[:\s]/i));
+    if (referencesMatch) {
+      // Only keep the part before references
+      if (referencesMatch.index === 0) {
+        // If references are at the start, there's no conclusion content
+        cleaned = "";
+      } else {
+        cleaned = cleaned.substring(0, referencesMatch.index).trim();
+      }
+    }
 
     // Remove asterisks, colons, and dashes
     cleaned = cleaned
@@ -281,8 +297,8 @@ export default function TensionResolution() {
         continue;
       }
 
-      // Check for Conclusion
-      if (line.match(/^\*?\*?Conclusion\*?\*?/i)) {
+      // Check for Conclusion - improved pattern to catch various formats
+      if (line.match(/^\*?\*?Conclusion\*?\*?/i) || line.match(/^Conclusion:/i)) {
         if (currentSection && currentContent.length > 0) {
           // Save previous section
           if (currentSection === 'attack') {
@@ -301,8 +317,8 @@ export default function TensionResolution() {
         continue;
       }
 
-      // Check for References
-      if (line.match(/^References?$/i)) {
+      // Check for References - improved pattern to catch various formats
+      if (line.match(/^\*?\*?References?\*?\*?$/i) || line.match(/^References?:/i)) {
         if (currentSection && currentContent.length > 0) {
           // Save previous section
           if (currentSection === 'attack') {
@@ -341,7 +357,27 @@ export default function TensionResolution() {
           cleanTensionResolutionPoint(currentContent.join('\n').trim())
         );
       } else if (currentSection === 'conclusion') {
-        conclusionFound = cleanConclusion(currentContent.join('\n').trim());
+        const conclusionText = currentContent.join('\n').trim();
+        
+        // Check if references section is embedded within conclusion
+        // This pattern matches various forms of "References" headings
+        const referencesMatch = conclusionText.match(/\n\s*\*?\*?References?\*?\*?[:\s]*/i) || 
+                               conclusionText.match(/\n\s*\[References?\]/i) ||
+                               conclusionText.match(/\n\s*References? section/i) ||
+                               (conclusionText.startsWith("References") && conclusionText.match(/^References?[:\s]/i));
+        if (referencesMatch) {
+          // Split the text into conclusion and references
+          if (referencesMatch.index === 0) {
+            // If references are at the start, there's no conclusion content
+            conclusionFound = "";
+            referencesFound = conclusionText.substring(referencesMatch[0].length).trim();
+          } else {
+            conclusionFound = cleanConclusion(conclusionText.substring(0, referencesMatch.index).trim());
+            referencesFound = conclusionText.substring(referencesMatch.index + referencesMatch[0].length).trim();
+          }
+        } else {
+          conclusionFound = cleanConclusion(conclusionText);
+        }
       } else if (currentSection === 'references') {
         referencesFound = currentContent.join('\n').trim();
       }


### PR DESCRIPTION
## Problem
In the tension-resolution page, the references section was not being properly separated from the conclusion section. This caused both sections to be displayed together, making it difficult to distinguish between the conclusion and the references.

## Solution
Enhanced the parsing logic to better detect and separate references from the conclusion:

1. Improved regex patterns to detect "References" sections in various formats:
   - Added support for "References:" format
   - Added support for "**References**" format with asterisks
   - Added support for "[References]" format
   - Added support for "References section" format
   - Added handling for cases where "References" appears at the beginning of text

2. Enhanced the `cleanConclusion` function to:
   - Check for and extract references that might be embedded within the conclusion text
   - Handle cases where references might be at the beginning of the conclusion text

3. Updated the `parseContentResponse` function to:
   - Better detect and separate references from conclusion text
   - Handle cases where references might be embedded within the conclusion section
   - Properly split the text into conclusion and references when both are present

## Testing
The changes have been tested with various formats of AI responses containing conclusion and references sections. The references are now properly separated from the conclusion and displayed in their own section on the page.

## Screenshots
No screenshots available as this is a code-level fix for parsing logic.