### PR TITLE
Add blank lines after title and Tension header in tension-resolution points

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -157,8 +157,11 @@ export default function TensionResolution() {
     cleaned = cleaned.replace(/^\*?\*?Tension-Resolution #\d+.*?\n?/i, '');
 
     // Look for title patterns like ": title**" or "**title**" and convert to proper bold HTML
-    cleaned = cleaned.replace(/^:\s*([^*\n]+)\*+\s*$/gm, '<strong>$1</strong>');
-    cleaned = cleaned.replace(/^\*+([^*\n]+)\*+\s*$/gm, '<strong>$1</strong>');
+    cleaned = cleaned.replace(/^:\s*([^*\n]+)\*+\s*$/gm, '<strong>$1</strong>\n');
+    cleaned = cleaned.replace(/^\*+([^*\n]+)\*+\s*$/gm, '<strong>$1</strong>\n');
+
+    // Add a blank line after "Tension:" if it exists
+    cleaned = cleaned.replace(/(Tension:.*?)(\n)/i, '$1\n$2');
 
     // Remove remaining asterisks, colons, and dashes
     cleaned = cleaned


### PR DESCRIPTION
## Changes Made
This PR adds blank lines in the tension-resolution points display to improve readability:

1. Added a blank line after the title (e.g., "Immune System Failure")
2. Added a blank line after the "Tension:" header

## Implementation Details
Modified the `cleanTensionResolutionPoint` function in the tension-resolution page to:
- Add a newline character after the title by modifying the regex replacements for title patterns
- Add a new regex replacement to add a blank line after the "Tension:" header

## Testing
The changes have been tested and confirmed to work as expected. The tension-resolution points now display with proper spacing between the title, tension header, and content.

## Screenshots
N/A - Visual changes to spacing in the tension-resolution points display.