### PR TITLE
Fix attack point parsing issue in tension-resolution page

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -177,7 +177,8 @@ export default function TensionResolution() {
     let cleaned = attackPoint.replace(/^Assistant:\s*/gm, '').trim();
 
     // Check if the content is wrapped in quotes and extract just the quoted content
-    const quotedContentMatch = cleaned.match(/["'"](.*?)["'"]/s);
+    // Only match if the entire content (or most of it) is wrapped in quotes
+    const quotedContentMatch = cleaned.match(/^["'"]([\s\S]*?)["'"]$/s);
     if (quotedContentMatch) {
       // If we found quoted content, use only that
       cleaned = quotedContentMatch[1].trim();


### PR DESCRIPTION
## Problem
The tension-resolution page had a critical parsing issue where attack point content was being truncated. Users would see incomplete text like "s decision could either halt or hasten the patient" instead of the full attack point content.

## Root Cause
The issue was in the `cleanAttackPoint` function's regex pattern `/["'"](.*?)["'"]/s` which was incorrectly matching apostrophes within the text (like "cardiologist's decision") and treating the content between apostrophes as quoted content, resulting in truncated display.

## Solution
- Fixed the regex pattern from `/["'"](.*?)["'"]/s` to `/^["'"]([\s\S]*?)["'"]$/s`
- The new pattern only matches content that is fully wrapped in quotes from start to end
- This prevents apostrophes within the text from being misinterpreted as quote delimiters

## Testing
- ✅ Verified attack points now display complete content without truncation
- ✅ Tested with multiple attack point generations
- ✅ Confirmed the Story Flow Outline section displays properly
- ✅ Verified the conversation flow continues to work correctly

## Changes Made
- Modified `src/app/story-flow-map/tension-resolution/page.tsx` line 181
- Updated regex pattern to be more specific about what constitutes "quoted content"

This fix resolves the user-reported issue where attack point content was being cut off and ensures the full medical story content is displayed properly.

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b09af5968c25475d9b659b1ad8ab0b31)