### PR TITLE
Fix CSC table formatting in tension-resolution page

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -355,22 +355,17 @@ export default function TensionResolution() {
       if (cells.length < 3) cells = [...cells, ...Array(3 - cells.length).fill('')];
       if (cells.length > 3) cells = cells.slice(0, 3);
 
-      // If row starts with CSC in the first column, ensure CSC content is in the Resolution column
+      // If row starts with CSC in the first column, separate the label from content
       const cscMatch = cells[0].match(/^CSC\s*:?\s*(.*)$/i);
       if (cscMatch) {
-        const extraFromFirstCol = (cscMatch[1] || '').trim();
-        // Prefer existing Resolution content; otherwise use Tension; otherwise use any trailing content from the first column label
-        let targetContent = cells[2] || cells[1] || extraFromFirstCol || '';
-        // Prefix with CSC label if not already
-        if (targetContent && !/^CSC\b/i.test(targetContent)) {
-          targetContent = `CSC: ${targetContent}`;
-        } else if (!targetContent) {
-          targetContent = 'CSC';
-        }
-        // Clear first column and move all content to Resolution, leaving Tension blank
-        cells[0] = '';
+        const cscContent = (cscMatch[1] || '').trim();
+        // Put "CSC" in the first column
+        cells[0] = 'CSC';
+        // Leave Tension column empty
         cells[1] = '';
-        cells[2] = targetContent;
+        // Put CSC content in the Resolution column, preferring existing Resolution content if any
+        let resolutionContent = cells[2] || cscContent || '';
+        cells[2] = resolutionContent;
       }
 
       return cells;

--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -364,7 +364,7 @@ export default function TensionResolution() {
         // Leave Tension column empty
         cells[1] = '';
         // Put CSC content in the Resolution column, preferring existing Resolution content if any
-        let resolutionContent = cells[2] || cscContent || '';
+        const resolutionContent = cells[2] || cscContent || '';
         cells[2] = resolutionContent;
       }
 


### PR DESCRIPTION
## Description
This PR fixes the table formatting issue on the tension-resolution page where the CSC (Core Story Concept) label and content were displayed in the same cell.

## Changes Made
- Modified the `parseMarkdownTable` function in `src/app/story-flow-map/tension-resolution/page.tsx`
- Separated CSC label from its content in table display
- **CSC** now appears in the first column (left) similar to how **AP** (Attack Point) is formatted
- CSC content is now properly placed in the Resolution column (right)
- Tension column is left empty for CSC rows

## Before
- CSC and its content were combined in the same cell
- Table formatting was inconsistent with AP rows

## After
- CSC label is in the first column (left)
- CSC content is in the Resolution column (right)
- Consistent formatting with AP rows
- Clean table structure maintained

## Testing
- Tested the fix by running the application locally
- Verified table generates correctly when user requests "Would you like the tension-resolution points put into a table?" and answers "yes"
- Confirmed CSC formatting now matches AP formatting structure

## Impact
- Improves table readability and consistency
- Maintains existing functionality for all other table rows
- No breaking changes to the user interface

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/27ec4a20487a4b7cbea5be2c40a88995)