### PR TITLE
Fix: Render TED Talk script only in Results pane (separate box under table)

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -1187,8 +1187,8 @@ export default function TensionResolution() {
         // Final restoration to ensure attack points are never lost
         // restoreAttackPoints();
 
-        // Update result if there's substantial content
-        if (content && content.length > 50) {
+        // Update result if there's substantial content and it's not a TED talk script
+        if (content && content.length > 50 && !tedTalkResult) {
           setResult(content);
         }
 

--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -1121,19 +1121,11 @@ export default function TensionResolution() {
           setTableData(tableResult);
         }
 
-        // Check if the response contains a TED talk script (only if user asked for one)
-        const userAskedForTedTalk =
-          trimmed.toLowerCase().includes('ted') ||
-          trimmed.toLowerCase().includes('script') ||
-          data.result.toLowerCase().includes('ted talk script');
-
-        let tedTalkResult = null;
-        if (userAskedForTedTalk) {
-          tedTalkResult = parseTedTalkScript(data.result);
-          console.log('TED talk parsing result:', tedTalkResult);
-          if (tedTalkResult) {
-            setTedTalkScript(tedTalkResult);
-          }
+        // Check if the response contains a TED talk script (always try to detect)
+        let tedTalkResult = parseTedTalkScript(data.result);
+        console.log('TED talk parsing result:', tedTalkResult);
+        if (tedTalkResult) {
+          setTedTalkScript(tedTalkResult);
         }
 
         // Parse the content to extract different sections
@@ -1290,6 +1282,7 @@ export default function TensionResolution() {
           conclusion ||
           references ||
           tableData ||
+          tedTalkScript ||
           result ? (
             <div className="bg-white border border-gray-300 p-6 rounded-lg shadow-md h-full flex flex-col">
               <div className="flex justify-between items-center mb-4 flex-shrink-0">

--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -1122,7 +1122,7 @@ export default function TensionResolution() {
         }
 
         // Check if the response contains a TED talk script (always try to detect)
-        let tedTalkResult = parseTedTalkScript(data.result);
+        const tedTalkResult = parseTedTalkScript(data.result);
         console.log('TED talk parsing result:', tedTalkResult);
         if (tedTalkResult) {
           setTedTalkScript(tedTalkResult);


### PR DESCRIPTION
Summary
- Ensures TED Talk scripts are rendered exclusively in the Results pane on the tension-resolution page, in a dedicated purple box beneath the Story Flow Table
- Prevents TED Talk content from appearing in the chat conversation pane

Changes
- Always parse API responses for TED Talk scripts and store them in `tedTalkScript`
- Suppress adding TED Talk content to chat messages; keep it only in the Results pane
- Include `tedTalkScript` in the results visibility condition so the pane opens even when only TED content exists
- Avoid overwriting the general `result` text with TED content

Files Modified
- src/app/story-flow-map/tension-resolution/page.tsx

Testing
1. Generate tension-resolution points
2. Ask for a TED Talk (answer the follow-up duration prompt)
3. Verify the TED Talk script appears only in the right Results pane (purple box) under the table, and does not appear in the conversation pane

Notes
- No PR template detected in the repository
- No server config changes; UI-only behavior adjustment

Co-authored-by: openhands <openhands@all-hands.dev>

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b3c00b3633f0431fae7731acdeb9fef7)