### PR TITLE
Fix conversation flow bug in tension-resolution page

### DIFF
--- a/src/app/story-flow-map/tension-resolution/page.tsx
+++ b/src/app/story-flow-map/tension-resolution/page.tsx
@@ -1226,31 +1226,47 @@ export default function TensionResolution() {
           responseContent = '';
         }
 
-        // Check if we generated attack points and need to ask the follow-up question
-        const shouldAskFollowUp =
-          parsedContent.attackPoints.length > 0 &&
-          !trimmed.toLowerCase().includes('move on') &&
-          !trimmed.toLowerCase().includes('tension');
-
-        if (shouldAskFollowUp) {
-          // Always ask the follow-up question after generating attack points
+        // Determine what question to ask based on the current state and what was just generated
+        if (tableResult) {
+          // If a table was just generated, ask about creating TED talk script
           setMessages((msgs) => [
             ...msgs,
             {
               role: 'assistant',
               content:
-                'Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?',
+                'Would you like me to write a script based on the above story flow outline that would be suitable for a highly engaging TED talk?',
             },
           ]);
-        } else if (responseContent.trim() && !tedTalkResult) {
-          // Only add to chat if there's content to add and it's not a TED talk script
-          setMessages((msgs) => [
-            ...msgs,
-            {
-              role: 'assistant',
-              content: responseContent,
-            },
-          ]);
+        } else {
+          // Check if we generated attack points and need to ask the follow-up question
+          const shouldAskAttackPointFollowUp =
+            parsedContent.attackPoints.length > 0 &&
+            !trimmed.toLowerCase().includes('move on') &&
+            !trimmed.toLowerCase().includes('tension') &&
+            // Only ask attack point follow-up if we don't already have tension-resolution points
+            // (i.e., we're still in the attack point phase)
+            tensionResolutionPoints.length === 0;
+
+          if (shouldAskAttackPointFollowUp) {
+            // Ask the attack point follow-up question
+            setMessages((msgs) => [
+              ...msgs,
+              {
+                role: 'assistant',
+                content:
+                  'Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?',
+              },
+            ]);
+          } else if (responseContent.trim() && !tedTalkResult) {
+            // Only add to chat if there's content to add and it's not a TED talk script
+            setMessages((msgs) => [
+              ...msgs,
+              {
+                role: 'assistant',
+                content: responseContent,
+              },
+            ]);
+          }
         }
       } catch (err) {
         console.error('Full error details:', err);


### PR DESCRIPTION
## Description

This PR fixes a bug in the story-flow-map/tension-resolution page where the AI was asking the wrong question after generating a table from tension-resolution points.

## Problem

After the user:
1. Generated tension-resolution points
2. Asked to put them into a table
3. Confirmed "yes" to create the table

The AI was incorrectly asking: "Would you like to modify this Attack Point, create a new one, or move on to creating tension-resolution points?"

Instead of the correct question: "Would you like me to write a script based on the above story flow outline that would be suitable for a highly engaging TED talk?"

## Solution

- Added logic to check if a table was just generated (`tableResult` is not null)
- If a table was generated, immediately ask about creating a TED talk script
- Only ask the attack point follow-up question when we're still in the attack point phase (i.e., when `tensionResolutionPoints.length === 0`)
- This ensures the correct conversation flow after table generation

## Changes Made

- Modified the conversation flow logic in `src/app/story-flow-map/tension-resolution/page.tsx` (lines 1229-1270)
- Replaced the simple attack point check with a more sophisticated state-aware flow control
- Added proper condition to only show attack point questions during the attack point phase

## Testing

- Tested the complete flow: Core Story Concept → Attack Point → Tension-Resolution Points → Table → TED Talk question
- Verified that the correct question is now asked after table generation
- Confirmed that attack point questions still work correctly during the attack point phase

## Impact

This fix ensures users can complete the full story flow outline process without getting stuck in an incorrect conversation loop after table generation.

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/249cbc384d54416ba7d42d2275431386)