### PR TITLE
Fix deck generation styling: remove colons and reduce spacing

### DIFF
--- a/src/app/slide-presentation/deck-generation/page.tsx
+++ b/src/app/slide-presentation/deck-generation/page.tsx
@@ -23,7 +23,7 @@ const softClean = (content: string): string =>
     .replace(/\n?\s*-{3,}\s*$/g, '') // remove trailing --- separators
     .trim();
 
-// Replace labels with styled HTML, make punctuation optional, and add a blank line after each label
+// Replace labels with styled HTML, remove punctuation, and add reduced spacing after each label
 const styleLabelsHtml = (content: string): string => {
   const esc = (content || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
@@ -34,13 +34,13 @@ const styleLabelsHtml = (content: string): string => {
   );
 
   // Style section labels at line start; accept optional :, -, – or — and any spacing
-  // Also force a colon and add an extra newline so there's an empty line underneath
+  // Remove any existing punctuation and add a single newline
   const labelRegex = /(^|\r?\n)(\s*)(TEXT|VISUALS|SPEAKER\s*NOTES|REFERENCES)\s*(?:[:\-–—])?/gi;
 
   const withStyledLabels = withStyledHeaders.replace(
     labelRegex,
     (_m, ls, indent, label) =>
-      `${ls}${indent}<span class="font-bold text-blue-700">${label.replace(/\s+/g, ' ').toUpperCase()}:</span>\n\n`
+      `${ls}${indent}<span class="font-bold text-blue-700">${label.replace(/\s+/g, ' ').toUpperCase()}</span>\n`
   );
 
   return withStyledLabels;


### PR DESCRIPTION
## Summary
This PR improves the visual presentation of generated slides on the deck generation page by removing colons from section headers and reducing vertical spacing.

## Changes Made
- **Remove colons from section headers**: 
  - `TEXT:` → `TEXT`
  - `VISUALS:` → `VISUALS`
  - `SPEAKER NOTES:` → `SPEAKER NOTES`
  - `REFERENCES:` → `REFERENCES`

- **Reduce vertical spacing by ~50%**:
  - Changed from double newlines (`\n\n`) to single newline (`\n`)
  - Creates tighter spacing between section headers and content

## Technical Details
- Modified the `styleLabelsHtml` function in `src/app/slide-presentation/deck-generation/page.tsx`
- Updated regex replacement to remove colon from template string
- Changed spacing from `\n\n` to `\n` for reduced vertical distance
- Updated comments to reflect new behavior

## Testing
- ✅ Created comprehensive test page to verify changes
- ✅ Confirmed JavaScript function works correctly with new styling
- ✅ TypeScript compilation passes without errors
- ✅ Main Next.js application runs successfully

## Visual Impact
The changes create cleaner, more professional-looking slide sections with:
- Cleaner section headers without trailing colons
- Tighter vertical spacing for better content density
- Improved readability and visual flow

## Files Changed
- `src/app/slide-presentation/deck-generation/page.tsx`

@jaburnell920 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7d45e61c681c4284a3d6c66af0467eb3)